### PR TITLE
Edit backend-statefulset storageClassName path

### DIFF
--- a/charts/langflow-ide/templates/backend-statefulset.yaml
+++ b/charts/langflow-ide/templates/backend-statefulset.yaml
@@ -145,7 +145,7 @@ spec:
           storage: {{ .Values.langflow.backend.sqlite.volume.size }}
       {{- if .Values.langflow.backend.sqlite.volume.existingStorageClassName }}
       {{- if ne .Values.langflow.backend.sqlite.volume.existingStorageClassName "default"}}
-      storageClassName: "{{ .Values.zookeeper.volumes.data.existingStorageClassName }}"
+      storageClassName: {{ .Values.langflow.backend.sqlite.volume.existingStorageClassName }}
       {{- else }}
       {{- end }}
       {{- else }}


### PR DESCRIPTION
In the values.yaml file, there is no zookeeper key. 
The Helm template expression in template/backend-statefulset.yaml should be changed.