### PR TITLE
Add SECRET_KEY for multi-replica Langflow backend

### DIFF
--- a/charts/langflow-ide/templates/backend-statefulset.yaml
+++ b/charts/langflow-ide/templates/backend-statefulset.yaml
@@ -132,6 +132,13 @@ spec:
             - name: LANGFLOW_NEW_USER_IS_ACTIVE
               value: "{{ .Values.langflow.backend.newUserIsActive | default "False" }}"
             {{- end }}
+            {{- if gt (int .Values.langflow.backend.replicaCount) 1 }}
+            - name: LANGFLOW_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "langflow.fullname" . }}
+                  key: SECRET_KEY
+            {{- end }}
           resources:
             {{- toYaml .Values.langflow.backend.resources | nindent 12 }}
       {{- with .Values.langflow.backend.nodeSelector }}

--- a/charts/langflow-ide/templates/secret.yaml
+++ b/charts/langflow-ide/templates/secret.yaml
@@ -1,0 +1,9 @@
+{{- if and (gt (int .Values.langflow.backend.replicaCount) 1) (not (lookup "v1" "Secret" .Release.Namespace "langflow-secrets")) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "langflow.fullname" . }}
+type: Opaque
+data:
+  SECRET_KEY: {{ randAlphaNum 32 | b64enc | b64enc | quote }}
+{{- end }}

--- a/charts/langflow-ide/values.yaml
+++ b/charts/langflow-ide/values.yaml
@@ -53,7 +53,7 @@ langflow:
       failureThreshold: 3
       periodSeconds: 10
       timeoutSeconds: 5
-      initialDelaySeconds: 5
+      initialDelaySeconds: 35
     env: []
     nodeSelector: {}
 


### PR DESCRIPTION
- Introduce SECRET_KEY environment variable for backend when replica count > 1
- Create a new secret.yaml template to store the SECRET_KEY
- Ensure SECRET_KEY is only added when running multiple replicas