### PR TITLE
WIP Add default securityContent and podSecurityContext values

### DIFF
--- a/charts/langflow-ide/templates/frontend-deployment.yaml
+++ b/charts/langflow-ide/templates/frontend-deployment.yaml
@@ -47,7 +47,7 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
-            {{- toYaml .Values.langflow.securityContext | nindent 12 }}
+            {{- toYaml .Values.langflow.frontend.securityContext | nindent 12 }}
           image: "{{ .Values.langflow.frontend.image.repository }}:{{ .Values.langflow.frontend.image.tag | default .Values.langflow.global.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.langflow.frontend.image.pullPolicy | default .Values.langflow.global.image.pullPolicy }}
           ports:
@@ -67,7 +67,7 @@ spec:
             initialDelaySeconds: {{ .Values.langflow.frontend.probe.initialDelaySeconds }}
             periodSeconds: {{ .Values.langflow.frontend.probe.periodSeconds }}
             timeoutSeconds: {{ .Values.langflow.frontend.probe.timeoutSeconds }}
-            failureThreshold: {{ .Values.langflow.frontend.probe.failureThreshold }}   
+            failureThreshold: {{ .Values.langflow.frontend.probe.failureThreshold }}
           readinessProbe:
             httpGet:
               path: /index.html
@@ -75,7 +75,7 @@ spec:
             initialDelaySeconds: {{ .Values.langflow.frontend.probe.initialDelaySeconds }}
             periodSeconds: {{ .Values.langflow.frontend.probe.periodSeconds }}
             timeoutSeconds: {{ .Values.langflow.frontend.probe.timeoutSeconds }}
-            failureThreshold: {{ .Values.langflow.frontend.probe.failureThreshold }}   
+            failureThreshold: {{ .Values.langflow.frontend.probe.failureThreshold }}
           env:
             - name: BACKEND_URL
               value: "http://{{ template "langflow.fullname" . }}-backend.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.langflow.backend.service.port }}"

--- a/charts/langflow-ide/values.yaml
+++ b/charts/langflow-ide/values.yaml
@@ -66,15 +66,23 @@ langflow:
       prometheus.io/port: "9090"
       prometheus.io/path: "/metrics"
 
-    securityContext: {}
-    # capabilities:
-    #   drop:
-    #   - ALL
-    # readOnlyRootFilesystem: true
-    # runAsNonRoot: true
-    # runAsUser: 1000
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+      readOnlyRootFilesystem: true
+      runAsUser: 1000
+      runAsNonRoot: true
+      runAsGroup: 1000
 
-    podSecurityContext: {}
+    podSecurityContext:
+      fsGroup: 1000
+      runAsUser: 1000
+      runAsNonRoot: true
+      runAsGroup: 1000
+
 
     externalDatabase:
       # Compose in the SQLAlchemy format: https://docs.sqlalchemy.org/en/20/core/engines.html#database-urls
@@ -133,7 +141,7 @@ langflow:
     # superuserPassword: <superuser password>
     # secretKey: <encryption key, optional>
     # newUserIsActive: true|false
-    
+
   frontend:
     enabled: true
     replicaCount: 1
@@ -162,14 +170,23 @@ langflow:
 
     affinity: {}
     podAnnotations: {}
-    podSecurityContext: {}
-    securityContext: {}
-    # capabilities:
-    #   drop:
-    #   - ALL
-    # readOnlyRootFilesystem: true
-    # runAsNonRoot: true
-    # runAsUser: 1000
+
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      privileged: false
+      readOnlyRootFilesystem: true
+      runAsUser: 1000
+      runAsNonRoot: true
+      runAsGroup: 1000
+
+    podSecurityContext:
+      fsGroup: 1000
+      runAsUser: 1000
+      runAsNonRoot: true
+      runAsGroup: 1000
 
 secretProvider:
   enabled: false

--- a/charts/langflow-runtime/values.yaml
+++ b/charts/langflow-runtime/values.yaml
@@ -31,16 +31,23 @@ serviceAccount:
 podAnnotations: {}
 podLabels: {}
 
-podSecurityContext: {}
-  # fsGroup: 2000
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+    - ALL
+  privileged: false
+  readOnlyRootFilesystem: true
+  runAsUser: 1000
+  runAsNonRoot: true
+  runAsGroup: 1000
 
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+podSecurityContext:
+  fsGroup: 1000
+  runAsUser: 1000
+  runAsNonRoot: true
+  runAsGroup: 1000
+
 env:
   - name: LANGFLOW_LOG_LEVEL
     value: "INFO"


### PR DESCRIPTION
Updates the default `securityContext` and `podSecurityContext` to more restrictive values including:

- Read-only root filesystem (requires container support / updates)
- Specifies non-root user and group
- Drops all capabilities
- Disallows privilege escalations
- Specifies non-privileged containers