### PR TITLE
feat: Include Env variables in frontend deployment template

### DIFF
--- a/charts/langflow-ide/templates/frontend-deployment.yaml
+++ b/charts/langflow-ide/templates/frontend-deployment.yaml
@@ -98,6 +98,8 @@ spec:
               value: "http://{{ template "langflow.fullname" . }}-backend.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.langflow.backend.service.port }}"
             - name: FRONTEND_PORT
               value: "{{ .Values.langflow.frontend.service.port }}"
+            - name: UPLOAD_LIMIT
+              value: "{{- range .Values.langflow.backend.env }}{{ if eq .name \"LANGFLOW_MAX_FILE_SIZE_UPLOAD\" }}{{ .value }}{{ end }}{{- end | default \"1M\" }}"
           resources:
             {{- toYaml .Values.langflow.frontend.resources | nindent 12 }}
       {{- with .Values.langflow.frontend.nodeSelector }}

--- a/charts/langflow-ide/templates/frontend-deployment.yaml
+++ b/charts/langflow-ide/templates/frontend-deployment.yaml
@@ -94,12 +94,13 @@ spec:
             timeoutSeconds: {{ .Values.langflow.frontend.probe.timeoutSeconds }}
             failureThreshold: {{ .Values.langflow.frontend.probe.failureThreshold }}   
           env:
+            {{with .Values.langflow.frontend.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
             - name: BACKEND_URL
               value: "http://{{ template "langflow.fullname" . }}-backend.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.langflow.backend.service.port }}"
             - name: FRONTEND_PORT
               value: "{{ .Values.langflow.frontend.service.port }}"
-            - name: LANGFLOW_MAX_FILE_SIZE_UPLOAD
-              value: "{{- range .Values.langflow.backend.env }}{{ if eq .name \"LANGFLOW_MAX_FILE_SIZE_UPLOAD\" }}{{ .value }}{{ end }}{{- end | default \"1M\" }}"
           resources:
             {{- toYaml .Values.langflow.frontend.resources | nindent 12 }}
       {{- with .Values.langflow.frontend.nodeSelector }}

--- a/charts/langflow-ide/templates/frontend-deployment.yaml
+++ b/charts/langflow-ide/templates/frontend-deployment.yaml
@@ -98,7 +98,7 @@ spec:
               value: "http://{{ template "langflow.fullname" . }}-backend.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.langflow.backend.service.port }}"
             - name: FRONTEND_PORT
               value: "{{ .Values.langflow.frontend.service.port }}"
-            - name: UPLOAD_LIMIT
+            - name: LANGFLOW_MAX_FILE_SIZE_UPLOAD
               value: "{{- range .Values.langflow.backend.env }}{{ if eq .name \"LANGFLOW_MAX_FILE_SIZE_UPLOAD\" }}{{ .value }}{{ end }}{{- end | default \"1M\" }}"
           resources:
             {{- toYaml .Values.langflow.frontend.resources | nindent 12 }}

--- a/examples/langflow-ide/dev-values-postgres.yaml
+++ b/examples/langflow-ide/dev-values-postgres.yaml
@@ -25,5 +25,10 @@ langflow:
           secretKeyRef:
             key: "password"
             name: "langflow-ide-postgresql-service"
+    frontend:
+      env: 
+        - name: LANGFLOW_MAX_FILE_SIZE_UPLOAD
+          value: "100"
+
     sqlite:
       enabled: false


### PR DESCRIPTION
In this PR from the main repo, I linked the nginx upload limit to the LANGFLOW_MAX_FILE_SIZE_UPLOAD env variable. https://github.com/langflow-ai/langflow/pull/7664

In order to take effect in the helm chart, the env variable must be passed to the frontend container.  