### PR TITLE
Make it possible to specify superuser, superuserPassword and secretKey securely using Kubernetes Secrets

### DIFF
--- a/charts/langflow-ide/Chart.yaml
+++ b/charts/langflow-ide/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: langflow-ide
 description: Helm chart for Langflow IDE
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: latest
 maintainers:
   - name: Langflow

--- a/charts/langflow-ide/templates/backend-statefulset.yaml
+++ b/charts/langflow-ide/templates/backend-statefulset.yaml
@@ -130,11 +130,11 @@ spec:
             - name: LANGFLOW_AUTO_LOGIN
               value: "{{ .Values.langflow.backend.autoLogin | default "False" }}"
             - name: LANGFLOW_SUPERUSER
-            {{- toYaml .Values.langflow.backend.superuser }}
+            {{- toYaml .Values.langflow.backend.superuser | nindent 14 }}
             - name: LANGFLOW_SUPERUSER_PASSWORD
-            {{- toYaml .Values.langflow.backend.superuserPassword }}
+            {{- toYaml .Values.langflow.backend.superuserPassword | nindent 14}}
             - name: LANGFLOW_SECRET_KEY
-            {{- toYaml .Values.langflow.backend.secretKey }}"
+            {{- toYaml .Values.langflow.backend.secretKey | nindent 14}}"
             - name: LANGFLOW_NEW_USER_IS_ACTIVE
               value: "{{ .Values.langflow.backend.newUserIsActive | default "False" }}"
             {{- end }}

--- a/charts/langflow-ide/templates/backend-statefulset.yaml
+++ b/charts/langflow-ide/templates/backend-statefulset.yaml
@@ -134,7 +134,7 @@ spec:
             - name: LANGFLOW_SUPERUSER_PASSWORD
             {{- toYaml .Values.langflow.backend.superuserPassword | nindent 14}}
             - name: LANGFLOW_SECRET_KEY
-            {{- toYaml .Values.langflow.backend.secretKey | nindent 14}}"
+            {{- toYaml .Values.langflow.backend.secretKey | nindent 14}}
             - name: LANGFLOW_NEW_USER_IS_ACTIVE
               value: "{{ .Values.langflow.backend.newUserIsActive | default "False" }}"
             {{- end }}

--- a/charts/langflow-ide/templates/backend-statefulset.yaml
+++ b/charts/langflow-ide/templates/backend-statefulset.yaml
@@ -130,11 +130,11 @@ spec:
             - name: LANGFLOW_AUTO_LOGIN
               value: "{{ .Values.langflow.backend.autoLogin | default "False" }}"
             - name: LANGFLOW_SUPERUSER
-              value: "{{ .Values.langflow.backend.superuser | default "admin" }}"
+            {{- toYaml .Values.langflow.backend.superuser }}
             - name: LANGFLOW_SUPERUSER_PASSWORD
-              value: "{{ .Values.langflow.backend.superuserPassword | default (randAlphaNum 32) }}"
+            {{- toYaml .Values.langflow.backend.superuserPassword }}
             - name: LANGFLOW_SECRET_KEY
-              value: "{{ .Values.langflow.backend.secretKey | default (randAlphaNum 32) }}"
+            {{- toYaml .Values.langflow.backend.secretKey }}"
             - name: LANGFLOW_NEW_USER_IS_ACTIVE
               value: "{{ .Values.langflow.backend.newUserIsActive | default "False" }}"
             {{- end }}

--- a/charts/langflow-ide/values.yaml
+++ b/charts/langflow-ide/values.yaml
@@ -190,9 +190,21 @@ langflow:
         storageClass: {}
 
     # autoLogin: true|false
-    # superuser: <superuser login>
-    # superuserPassword: <superuser password>
-    # secretKey: <encryption key, optional>
+    # superuser: {}
+        # valueFrom:
+        #   secretKeyRef:
+        #    key: password
+        #    name: <secret-name>
+    # superuserPassword: {}
+        # valueFrom:
+        #   secretKeyRef:
+        #    key: password
+        #    name: <secret-name>
+    # secretKey: {}
+        # valueFrom:
+        #   secretKeyRef:
+        #    key: password
+        #    name: <secret-name>
     # newUserIsActive: true|false
 
   frontend:


### PR DESCRIPTION
Fixes #54

Currently in backend-statefulset.yaml, parameters from value.yaml are directly copied into value. This prevents Kubernetes Secrets from being used & instead requires hard-coding these into values.yaml. With this implementaion, if we use Kubernetes Secrets in values.yaml, a string representation of the yaml gets copied over instead of the correct reference.
```
            - name: LANGFLOW_SUPERUSER
              value: "{{ .Values.langflow.backend.superuser | default "admin" }}"
            - name: LANGFLOW_SUPERUSER_PASSWORD
              value: "{{ .Values.langflow.backend.superuserPassword | default (randAlphaNum 32) }}"
            - name: LANGFLOW_SECRET_KEY
              value: "{{ .Values.langflow.backend.secretKey | default (randAlphaNum 32) }}"
```
Database settings are correctly handled and implementing this style will let secrets be used for superuser as well
```
            - name: LF_CHART_EXTERNALDB_DATABASE
            {{- toYaml .Values.langflow.backend.externalDatabase.database | nindent 14 }}
            - name: LF_CHART_EXTERNALDB_USER
            {{- toYaml .Values.langflow.backend.externalDatabase.user | nindent 14 }}
            - name: LF_CHART_EXTERNALDB_PASSWORD
            {{- toYaml .Values.langflow.backend.externalDatabase.password | nindent 14 }}
```
Additionally, setting admin password as a random default is worse than useless as then no one can ever login. It should not be optional. Similarly, SecretKey is ideally not optional if autologin is provided

This fix implements the same style as used in Database settings to superuser