### PR TITLE
Fix annotations rendering for backend StatefulSet

### DIFF
--- a/charts/langflow-ide/templates/backend-statefulset.yaml
+++ b/charts/langflow-ide/templates/backend-statefulset.yaml
@@ -18,7 +18,7 @@ spec:
       langflow-scope: "backend"
   template:
     metadata:
-      {{- with .Values.langflow.podAnnotations }}
+      {{- with .Values.langflow.backend.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
fix: langflow.podannotations do not exist